### PR TITLE
Persona Streaming UI: badges + stability playbook; scope refactor

### DIFF
--- a/docs/dev/stability-playbook.md
+++ b/docs/dev/stability-playbook.md
@@ -1,0 +1,36 @@
+## Dev stability playbook (WSL + Next.js)
+
+### Why things have broken historically
+- WSL port reuse: Node dev server leaves port 4000 in TIME_WAIT, causing `EADDRINUSE` on restart.
+- Stale Next build cache: old webpack chunks in `.next/` trigger missing module errors (e.g., `Cannot find module './948.js'`).
+- Race to ready: UI reported “up” before it actually served 200, resulting in white screens/500s.
+- Duplicate/invalid API modules: accidental duplicate exports or route collisions (e.g., models route) break builds.
+- Flaky smoke in CI: long timeouts and multi-route checks hung runs.
+- Build vs. runtime assumptions: fetching internal routes or importing server-only code in unexpected places can surface at build.
+
+### Mitigations we implemented
+- Start script hardening: `./blueforce-start.sh` frees 4000/tcp, cleans `.next/`, and waits for HTTP 200.
+- Clean builds: `rm -rf .next` in `npm run build` to avoid stale chunks.
+- Health checks: `./blueforce-start.sh status` and `curl /` after changes; tail `logs/next.log` on errors.
+- Simplified CI: removed flaky smoke; kept lint+build with timeouts.
+- Safer API routes: deduped `/api/ollama/models`; client-only fetches moved into `useEffect`.
+
+### Guardrails (do every time)
+1) `npm ci && npm run build` (clean build).
+2) `./blueforce-start.sh restart`; wait for “UI ready”.
+3) `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4000/` → expect 200.
+4) Hit key routes: `/pm-dashboard`, `/ontology` → expect 200.
+5) `tail -n 200 logs/next.log` to confirm no runtime errors.
+
+### Coding guidelines that help
+- Keep API and server utilities free of client-only imports.
+- Fetch internal APIs from client `useEffect` (not during build/SSR) unless necessary.
+- One change per PR, small and focused; run build + health checks pre-push.
+- Prefer feature branches; squash-merge after green checks.
+
+### If it still breaks
+- Re-run steps above; if 500 persists, delete `.next/`, restart, and review `logs/next.log`.
+- Check for duplicate route files or conflicting exports.
+- Verify WSL hasn’t orphaned the port: `fuser -k 4000/tcp` (handled by the start script).
+
+

--- a/logs/next.log
+++ b/logs/next.log
@@ -7,44 +7,9 @@
   - Environments: .env.local
 
  ✓ Starting...
- ✓ Ready in 2.1s
+ ✓ Ready in 1614ms
  ○ Compiling / ...
- ✓ Compiled / in 4.6s (466 modules)
- GET / 200 in 4961ms
- GET / 200 in 2760ms
- GET / 200 in 120ms
- GET / 200 in 26ms
- GET / 200 in 23ms
- ○ Compiling /pm-dashboard ...
- ✓ Compiled /ontology in 1099ms (463 modules)
- GET /pm-dashboard 200 in 1300ms
- GET /ontology 200 in 596ms
- GET /ontology 200 in 55ms
- ✓ Compiled /api/ontology/artifacts in 200ms (267 modules)
- GET /api/ontology/artifacts 200 in 315ms
- GET /api/ontology/artifacts 200 in 16ms
- GET /pm-dashboard 200 in 116ms
- ✓ Compiled /api/ontology/metrics in 109ms (269 modules)
- ✓ Compiled (271 modules)
- GET /api/ontology/artifacts 200 in 336ms
- GET /api/ontology/metrics 200 in 357ms
- GET /api/health/ollama 200 in 364ms
- GET /api/ontology/artifacts 200 in 46ms
- GET /api/ontology/metrics 200 in 24ms
- GET /api/health/ollama 200 in 29ms
- ✓ Compiled /api/workflows/cop-demo/start in 102ms (275 modules)
- POST /api/workflows/cop-demo/start 200 in 143ms
- ✓ Compiled /api/workflows/[id]/status in 65ms (277 modules)
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 371ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 23ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 25ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 15ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 15ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 17ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 28ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 16ms
- GET /api/workflows/7wg8till09n65dsuqpebuk/status 200 in 26ms
- ✓ Compiled /api/ontology/artifacts/[name] in 122ms (267 modules)
- GET /api/ontology/artifacts/cdm_link16.json 200 in 433ms
- GET /api/ontology/artifacts/cdm_vmf.json 200 in 19ms
- ✓ Compiled in 264ms (246 modules)
+ ✓ Compiled / in 2.8s (466 modules)
+ GET / 200 in 3012ms
+ GET / 200 in 50ms
+[?25h


### PR DESCRIPTION
This PR (PR2) enhances the Ontology workspace persona experience and documents stability guardrails.

- Ontology UI: Persona Output now shows per-persona status badges (working with spinner, then check); global streaming indicator; clear action.
- Streaming refactor: move `streamPersona` inside component to fix setState scope and runtime errors.
- Stability docs: docs/dev/stability-playbook.md capturing WSL port reuse, stale cache, duplicate route pitfalls, and our guardrails.

Verification
- Clean build, restart via ./blueforce-start.sh, 200 on /, /pm-dashboard, /ontology.
- Streaming verified for Standards Analyst and Data Modeler with available Ollama models.

Follow-up
- Add deterministic fallback text if Ollama missing.
- Structured rendering for Data Modeler (mapping/conflicts table).

Workflow: short-lived branch, squash-merge after green checks.