### PR TITLE
Schema extraction stub (Link-16/VMF): fixtures, API, and UI previews

### DIFF
--- a/app/api/standards/schemas/route.ts
+++ b/app/api/standards/schemas/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { extractSchemaFromFixtures, listAvailableStandards } from '@/lib/standards';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const standard = (searchParams.get('standard') || '').toLowerCase() as 'link16' | 'vmf' | '';
+  if (!standard) {
+    const available = await listAvailableStandards();
+    return NextResponse.json({ available });
+  }
+  if (!['link16','vmf'].includes(standard)) {
+    return NextResponse.json({ error: 'unsupported standard' }, { status: 400 });
+  }
+  const schema = await extractSchemaFromFixtures(standard);
+  return NextResponse.json(schema);
+}
+
+

--- a/app/ontology/page.tsx
+++ b/app/ontology/page.tsx
@@ -22,6 +22,7 @@ export default function OntologyPage() {
     STANDARDS_ANALYST: false,
     DATA_MODELER: false
   });
+  const [schemas, setSchemas] = useState<{ link16?: any; vmf?: any }>({});
 
   const index = useMemo(() => {
     const map = new Map(artifacts.map((a) => [a.name, a] as const));
@@ -53,6 +54,11 @@ export default function OntologyPage() {
         try { if (chosen) localStorage.setItem('ollama:model', chosen); } catch {}
       })
       .catch(() => {});
+    // Preload deterministic schema fixtures via API (stub extraction)
+    Promise.all([
+      fetch('/api/standards/schemas?standard=link16').then(r => (r.ok ? r.json() : null)).catch(() => null),
+      fetch('/api/standards/schemas?standard=vmf').then(r => (r.ok ? r.json() : null)).catch(() => null),
+    ]).then(([l16, vmf]) => setSchemas({ link16: l16, vmf })).catch(() => {});
   }, []);
 
   // Stream persona output from the server and append to the matching buffer
@@ -198,6 +204,12 @@ export default function OntologyPage() {
             action={index.link16 ? (<button className="underline" onClick={() => open(index.link16!.name)} disabled={step < 1}>Preview</button>) : null}
           >
             <ArtifactSummary item={index.link16} disabled={step < 1} />
+            {schemas.link16 && (
+              <details className="mt-2 text-xs">
+                <summary className="cursor-pointer opacity-80">Preview extracted schema (stub)</summary>
+                <pre className="mt-2" style={{ whiteSpace: 'pre-wrap' }}>{safePrettyJson(JSON.stringify(schemas.link16))}</pre>
+              </details>
+            )}
           </Panel>
           <Panel
             title="VMF (Extracted)"
@@ -205,6 +217,12 @@ export default function OntologyPage() {
             action={index.vmf ? (<button className="underline" onClick={() => open(index.vmf!.name)} disabled={step < 2}>Preview</button>) : null}
           >
             <ArtifactSummary item={index.vmf} disabled={step < 2} />
+            {schemas.vmf && (
+              <details className="mt-2 text-xs">
+                <summary className="cursor-pointer opacity-80">Preview extracted schema (stub)</summary>
+                <pre className="mt-2" style={{ whiteSpace: 'pre-wrap' }}>{safePrettyJson(JSON.stringify(schemas.vmf))}</pre>
+              </details>
+            )}
           </Panel>
         </section>
 

--- a/fixtures/standards/link16_schema.json
+++ b/fixtures/standards/link16_schema.json
@@ -1,0 +1,30 @@
+{
+  "standard": "Link-16",
+  "version": "mock-1.0",
+  "entities": [
+    {
+      "name": "Track",
+      "fields": [
+        { "name": "trackId", "type": "string", "required": true },
+        { "name": "lat", "type": "number", "required": true },
+        { "name": "lon", "type": "number", "required": true },
+        { "name": "speed", "type": "number", "required": false },
+        { "name": "heading", "type": "number", "required": false }
+      ]
+    },
+    {
+      "name": "Unit",
+      "fields": [
+        { "name": "unitId", "type": "string", "required": true },
+        { "name": "platform", "type": "string", "required": false }
+      ]
+    }
+  ],
+  "rules": [
+    { "rule": "lat_range", "target": "Track.lat", "type": "range", "min": -90, "max": 90 },
+    { "rule": "lon_range", "target": "Track.lon", "type": "range", "min": -180, "max": 180 },
+    { "rule": "track_id_format", "target": "Track.trackId", "type": "regex", "pattern": "^[A-Z0-9]{4,12}$" }
+  ]
+}
+
+

--- a/fixtures/standards/vmf_schema.json
+++ b/fixtures/standards/vmf_schema.json
@@ -1,0 +1,27 @@
+{
+  "standard": "VMF",
+  "version": "mock-1.0",
+  "entities": [
+    {
+      "name": "Message",
+      "fields": [
+        { "name": "messageId", "type": "string", "required": true },
+        { "name": "messageType", "type": "string", "required": true },
+        { "name": "timestamp", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "Position",
+      "fields": [
+        { "name": "lat", "type": "number", "required": true },
+        { "name": "lon", "type": "number", "required": true },
+        { "name": "alt", "type": "number", "required": false }
+      ]
+    }
+  ],
+  "rules": [
+    { "rule": "timestamp_iso8601", "target": "Message.timestamp", "type": "format", "format": "iso8601" }
+  ]
+}
+
+

--- a/lib/standards.ts
+++ b/lib/standards.ts
@@ -1,0 +1,34 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export type StandardKind = 'link16' | 'vmf';
+
+export interface ExtractedSchema {
+  standard: string;
+  version: string;
+  entities: Array<{
+    name: string;
+    fields: Array<{ name: string; type: string; required?: boolean }>;
+  }>;
+  rules: Array<Record<string, unknown>>;
+}
+
+const FIXTURES_DIR = path.join(process.cwd(), 'fixtures', 'standards');
+
+export async function listAvailableStandards(): Promise<StandardKind[]> {
+  return ['link16', 'vmf'];
+}
+
+export async function readSchemaFixture(kind: StandardKind): Promise<ExtractedSchema> {
+  const file = kind === 'link16' ? 'link16_schema.json' : 'vmf_schema.json';
+  const p = path.join(FIXTURES_DIR, file);
+  const raw = await fs.readFile(p, 'utf8');
+  return JSON.parse(raw);
+}
+
+export async function extractSchemaFromFixtures(kind: StandardKind): Promise<ExtractedSchema> {
+  // Deterministic stub: simply returns curated fixtures for now
+  return readSchemaFixture(kind);
+}
+
+

--- a/logs/next.log
+++ b/logs/next.log
@@ -7,9 +7,9 @@
   - Environments: .env.local
 
  ✓ Starting...
- ✓ Ready in 1614ms
+ ✓ Ready in 1639ms
  ○ Compiling / ...
- ✓ Compiled / in 2.8s (466 modules)
- GET / 200 in 3012ms
- GET / 200 in 50ms
+ ✓ Compiled / in 2.9s (466 modules)
+ GET / 200 in 3142ms
+ GET / 200 in 52ms
 [?25h


### PR DESCRIPTION
PR3 introduces a deterministic schema extraction stub:

- Fixtures: `fixtures/standards/link16_schema.json`, `vmf_schema.json`
- Lib: `lib/standards.ts` to list standards and return curated schemas
- API: `GET /api/standards/schemas` (list) and `?standard=link16|vmf` (return schema)
- UI: `/ontology` shows stub schema preview under Link-16/VMF cards

Verification
- Clean build, restart via ./blueforce-start.sh, 200 on routes
- API: `/api/standards/schemas` lists [link16, vmf]; `/api/standards/schemas?standard=link16` returns Track entity

Follow-ups
- Wire rules-driven extraction from uploaded/mocked source documents
- Promote schema/rules into alignment/conflict views where relevant